### PR TITLE
Added Mechagon chests

### DIFF
--- a/Treasure.lua
+++ b/Treasure.lua
@@ -14,6 +14,7 @@ local AZERITE = 1553
 local CHEST = 'Treasure Chest'
 local CHEST_SM = 'Small Treasure Chest'
 local CHEST_GLIM = 'Glimmering Treasure Chest'
+local CHEST_MECH = 'Mechanized Chest'
 
 local path_meta = {__index = {
     label = "Path to treasure",
@@ -346,5 +347,64 @@ ns.points = {
 		[80503190] = {quest=56547, minimap=true, achievement=13549, label=AR_TRUNK, note="Up the building"}, [83003380] = path{quest=56547}, -- game quest id: 56913
     },
     [1462] = { -- Mechagon
+        -- Chest 1, 325659
+        [43504990] = {quest=55547, criteria=0, label=CHEST_MECH, note="Mechanized Chest 1"},  -- Coords from wowhead
+        [52205350] = {quest=55547, criteria=0, label=CHEST_MECH, note="Mechanized Chest 1"},  -- Coords from wowhead
+        [53204170] = {quest=55547, criteria=0, label=CHEST_MECH, note="Mechanized Chest 1"},  -- Coords from wowhead
+        [49503020] = {quest=55547, criteria=0, label=CHEST_MECH, note="Mechanized Chest 1"},  -- Coords from wowhead
+        [57003880] = {quest=55547, criteria=0, label=CHEST_MECH, note="Mechanized Chest 1"},  -- Coords from wowhead
+        [56973861] = {quest=55547, criteria=0, label=CHEST_MECH, note="Mechanized Chest 1"},
+        -- Chest 2, 325660
+        [35703850] = {quest=55548, criteria=0, label=CHEST_MECH, note="Mechanized Chest 2"},  -- Coords from wowhead
+        [30785183] = {quest=55548, criteria=0, label=CHEST_MECH, note="Mechanized Chest 2"},
+        [40005410] = {quest=55548, criteria=0, label=CHEST_MECH, note="Mechanized Chest 2"},  -- Coords from wowhead
+        [20707130] = {quest=55548, criteria=0, label=CHEST_MECH, note="Mechanized Chest 2"},  -- Coords from wowhead
+        -- Chest 3, 325661
+        [80504850] = {quest=55549, criteria=0, label=CHEST_MECH, note="Mechanized Chest 3"},  -- Coords from wowhead
+        [73515334] = {quest=55549, criteria=0, label=CHEST_MECH, note="Mechanized Chest 3"},
+        [67205650] = {quest=55549, criteria=0, label=CHEST_MECH, note="Mechanized Chest 3"},  -- Coords from wowhead
+        [65866460] = {quest=55549, criteria=0, label=CHEST_MECH, note="Mechanized Chest 3"},
+        [59946357] = {quest=55549, criteria=0, label=CHEST_MECH, note="Mechanized Chest 3"},
+        -- Chest 4, 325662
+        [65555284] = {quest=55550, criteria=0, label=CHEST_MECH, note="Mechanized Chest 4"},
+        [72704720] = {quest=55550, criteria=0, label=CHEST_MECH, note="Mechanized Chest 4"},  -- Coords from wowhead
+        [73014950] = {quest=55550, criteria=0, label=CHEST_MECH, note="Mechanized Chest 4"},
+        [76215286] = {quest=55550, criteria=0, label=CHEST_MECH, note="Mechanized Chest 4"},
+        [81106150] = {quest=55550, criteria=0, label=CHEST_MECH, note="Mechanized Chest 4"},
+        -- Chest 5, 325663
+        [61403250] = {quest=55551, criteria=0, label=CHEST_MECH, note="Mechanized Chest 5"},  -- Coords from wowhead
+        [58804170] = {quest=55551, criteria=0, label=CHEST_MECH, note="Mechanized Chest 5"},  -- Coords from wowhead
+        [70604780] = {quest=55551, criteria=0, label=CHEST_MECH, note="Mechanized Chest 5"},  -- Coords from wowhead
+        [64505960] = {quest=55551, criteria=0, label=CHEST_MECH, note="Mechanized Chest 5"},  -- Coords from wowhead
+        [56705750] = {quest=55551, criteria=0, label=CHEST_MECH, note="Mechanized Chest 5"},  -- Coords from wowhead
+        -- Chest 6, 325664
+        [66502250] = {quest=55552, criteria=0, label=CHEST_MECH, note="Mechanized Chest 6"},  -- Coords from wowhead
+        [64002650] = {quest=55552, criteria=0, label=CHEST_MECH, note="Mechanized Chest 6"},  -- Coords from wowhead
+        [56782918] = {quest=55552, criteria=0, label=CHEST_MECH, note="Mechanized Chest 6"},
+        [57302290] = {quest=55552, criteria=0, label=CHEST_MECH, note="Mechanized Chest 6"},  -- Coords from wowhead
+        [55612404] = {quest=55552, criteria=0, label=CHEST_MECH, note="Mechanized Chest 6"},
+        [50802860] = {quest=55552, criteria=0, label=CHEST_MECH, note="Mechanized Chest 6"},  -- Coords from wowhead
+        -- Chest 7, 325665
+        [67452470] = {quest=55553, criteria=0, label=CHEST_MECH, note="Mechanized Chest 7"},
+        [80801870] = {quest=55553, criteria=0, label=CHEST_MECH, note="Mechanized Chest 7"},  -- Coords from wowhead
+        [86232042] = {quest=55553, criteria=0, label=CHEST_MECH, note="Mechanized Chest 7"},
+        [88602050] = {quest=55553, criteria=0, label=CHEST_MECH, note="Mechanized Chest 7"},  -- Coords from wowhead
+        [85602850] = {quest=55553, criteria=0, label=CHEST_MECH, note="Mechanized Chest 7"},  -- Coords from wowhead
+        -- Chest 8, 325666
+        [48367595] = {quest=55554, criteria=0, label=CHEST_MECH, note="Mechanized Chest 8"},
+        [57258202] = {quest=55554, criteria=0, label=CHEST_MECH, note="Mechanized Chest 8"},
+        [62607400] = {quest=55554, criteria=0, label=CHEST_MECH, note="Mechanized Chest 8"},  -- Coords from wowhead
+        [66707740] = {quest=55554, criteria=0, label=CHEST_MECH, note="Mechanized Chest 8"},  -- Coords from wowhead
+        -- Chest 9, 325667
+        [63606750] = {quest=55555, criteria=0, label=CHEST_MECH, note="Mechanized Chest 9"},  -- Coords from wowhead
+        [72126545] = {quest=55555, criteria=0, label=CHEST_MECH, note="Mechanized Chest 9"},
+        [76516601] = {quest=55555, criteria=0, label=CHEST_MECH, note="Mechanized Chest 9"},
+        [81167231] = {quest=55555, criteria=0, label=CHEST_MECH, note="Mechanized Chest 9"},
+        [85106350] = {quest=55555, criteria=0, label=CHEST_MECH, note="Mechanized Chest 9"},
+        -- Chest 10, 325668
+        [24806550] = {quest=55556, criteria=0, label=CHEST_MECH, note="Mechanized Chest 10"},  -- Coords from wowhead
+        [20607700] = {quest=55556, criteria=0, label=CHEST_MECH, note="Mechanized Chest 10"},  -- Coords from wowhead
+        [21788303] = {quest=55556, criteria=0, label=CHEST_MECH, note="Mechanized Chest 10"},
+        [12088566] = {quest=55556, criteria=0, label=CHEST_MECH, note="Mechanized Chest 10"},
     },
 }


### PR DESCRIPTION
There are 10 distinct chests, each with multiple (4-6 known at this time) spawn points.  Each chest/group is gated by a daily so you can only loot it once per day, for a maximum of 10 chests.  Using this addon to track them is useful, because the grouped spawns disappear from the map when you loot one, and so it's easy to tell where to look when trying to find those last couple of chests for quest items.

I've personally verified the coordinates of the entries that don't have the "wowhead coords" comment.  I'll be verifying and refining the locations as days pass and they become available again to my alts.