### PR TITLE
Filter Mechanized chests based on Normal-vs-Alternate Time

### DIFF
--- a/Treasure.lua
+++ b/Treasure.lua
@@ -384,7 +384,7 @@ ns.points = {
         [66432227] = {quest=55552, criteria=0, label=CHEST_MECH, requires_no_buff=296644, note="Chest 5 (of 9 in Normal Time)"},
         [64092627] = {quest=55552, criteria=0, label=CHEST_MECH, requires_no_buff=296644, note="Chest 5 (of 9 in Normal Time)"},
         [56782918] = {quest=55552, criteria=0, label=CHEST_MECH, requires_no_buff=296644, note="Chest 5 (of 9 in Normal Time)"},
-        [57302290] = {quest=55552, criteria=0, label=CHEST_MECH, requires_no_buff=296644, note="Chest 5 (of 9 in Normal Time)"},  -- Coords from wowhead
+        [57142283] = {quest=55552, criteria=0, label=CHEST_MECH, requires_no_buff=296644, note="Chest 5 (of 9 in Normal Time)"},
         [55612404] = {quest=55552, criteria=0, label=CHEST_MECH, requires_no_buff=296644, note="Chest 5 (of 9 in Normal Time)"},
         [50662858] = {quest=55552, criteria=0, label=CHEST_MECH, requires_no_buff=296644, note="Chest 5 (of 9 in Normal Time)"},
         -- 325665

--- a/Treasure.lua
+++ b/Treasure.lua
@@ -350,63 +350,62 @@ ns.points = {
     },
     [1462] = { -- Mechagon
         -- Chest 1, 325659
-        [43504990] = {quest=55547, criteria=0, label=CHEST_MECH, note="Mechanized Chest 1"},  -- Coords from wowhead
-        [52205350] = {quest=55547, criteria=0, label=CHEST_MECH, note="Mechanized Chest 1"},  -- Coords from wowhead
-        [53204170] = {quest=55547, criteria=0, label=CHEST_MECH, note="Mechanized Chest 1"},  -- Coords from wowhead
-        [49503020] = {quest=55547, criteria=0, label=CHEST_MECH, note="Mechanized Chest 1"},  -- Coords from wowhead
-        [57003880] = {quest=55547, criteria=0, label=CHEST_MECH, note="Mechanized Chest 1"},  -- Coords from wowhead
-        [56973861] = {quest=55547, criteria=0, label=CHEST_MECH, note="Mechanized Chest 1"},
+        [43304977] = {quest=55547, criteria=0, label=CHEST_MECH, requires_no_buff=296644, note="Mechanized Chest 1"},
+        [52115326] = {quest=55547, criteria=0, label=CHEST_MECH, requires_no_buff=296644, note="Mechanized Chest 1"},
+        [53254190] = {quest=55547, criteria=0, label=CHEST_MECH, requires_no_buff=296644, note="Mechanized Chest 1"},
+        [49223021] = {quest=55547, criteria=0, label=CHEST_MECH, requires_no_buff=296644, note="Mechanized Chest 1"},
+        [56973861] = {quest=55547, criteria=0, label=CHEST_MECH, requires_no_buff=296644, note="Mechanized Chest 1"},
         -- Chest 2, 325660
-        [35703850] = {quest=55548, criteria=0, label=CHEST_MECH, note="Mechanized Chest 2"},  -- Coords from wowhead
-        [30785183] = {quest=55548, criteria=0, label=CHEST_MECH, note="Mechanized Chest 2"},
-        [40005410] = {quest=55548, criteria=0, label=CHEST_MECH, note="Mechanized Chest 2"},  -- Coords from wowhead
-        [20707130] = {quest=55548, criteria=0, label=CHEST_MECH, note="Mechanized Chest 2"},  -- Coords from wowhead
+        [35683833] = {quest=55548, criteria=0, label=CHEST_MECH, requires_no_buff=296644, note="Mechanized Chest 2"},
+        [30785183] = {quest=55548, criteria=0, label=CHEST_MECH, requires_no_buff=296644, note="Mechanized Chest 2"},
+        [40155409] = {quest=55548, criteria=0, label=CHEST_MECH, requires_no_buff=296644, note="Mechanized Chest 2"},
+        [20617141] = {quest=55548, criteria=0, label=CHEST_MECH, requires_no_buff=296644, note="Mechanized Chest 2"},
         -- Chest 3, 325661
-        [80504850] = {quest=55549, criteria=0, label=CHEST_MECH, note="Mechanized Chest 3"},  -- Coords from wowhead
-        [73515334] = {quest=55549, criteria=0, label=CHEST_MECH, note="Mechanized Chest 3"},
-        [67205650] = {quest=55549, criteria=0, label=CHEST_MECH, note="Mechanized Chest 3"},  -- Coords from wowhead
-        [65866460] = {quest=55549, criteria=0, label=CHEST_MECH, note="Mechanized Chest 3"},
-        [59946357] = {quest=55549, criteria=0, label=CHEST_MECH, note="Mechanized Chest 3"},
+        [80504850] = {quest=55549, criteria=0, label=CHEST_MECH, requires_no_buff=296644, note="Mechanized Chest 3"},  -- Coords from wowhead
+        [73515334] = {quest=55549, criteria=0, label=CHEST_MECH, requires_no_buff=296644, note="Mechanized Chest 3"},
+        [67075645] = {quest=55549, criteria=0, label=CHEST_MECH, requires_no_buff=296644, note="Mechanized Chest 3"},
+        [65866460] = {quest=55549, criteria=0, label=CHEST_MECH, requires_no_buff=296644, note="Mechanized Chest 3"},
+        [59946357] = {quest=55549, criteria=0, label=CHEST_MECH, requires_no_buff=296644, note="Mechanized Chest 3"},
         -- Chest 4, 325662
-        [65555284] = {quest=55550, criteria=0, label=CHEST_MECH, note="Mechanized Chest 4"},
-        [72704720] = {quest=55550, criteria=0, label=CHEST_MECH, note="Mechanized Chest 4"},  -- Coords from wowhead
-        [73014950] = {quest=55550, criteria=0, label=CHEST_MECH, note="Mechanized Chest 4"},
-        [76215286] = {quest=55550, criteria=0, label=CHEST_MECH, note="Mechanized Chest 4"},
-        [81106150] = {quest=55550, criteria=0, label=CHEST_MECH, note="Mechanized Chest 4"},
-        -- Chest 5, 325663
-        [61403250] = {quest=55551, criteria=0, label=CHEST_MECH, note="Mechanized Chest 5"},  -- Coords from wowhead
-        [58804170] = {quest=55551, criteria=0, label=CHEST_MECH, note="Mechanized Chest 5"},  -- Coords from wowhead
-        [70604780] = {quest=55551, criteria=0, label=CHEST_MECH, note="Mechanized Chest 5"},  -- Coords from wowhead
-        [64505960] = {quest=55551, criteria=0, label=CHEST_MECH, note="Mechanized Chest 5"},  -- Coords from wowhead
-        [56705750] = {quest=55551, criteria=0, label=CHEST_MECH, note="Mechanized Chest 5"},  -- Coords from wowhead
+        [65555284] = {quest=55550, criteria=0, label=CHEST_MECH, requires_no_buff=296644, note="Mechanized Chest 4"},
+        [72594733] = {quest=55550, criteria=0, label=CHEST_MECH, requires_no_buff=296644, note="Mechanized Chest 4"},
+        [73014950] = {quest=55550, criteria=0, label=CHEST_MECH, requires_no_buff=296644, note="Mechanized Chest 4"},
+        [76215286] = {quest=55550, criteria=0, label=CHEST_MECH, requires_no_buff=296644, note="Mechanized Chest 4"},
+        [81106150] = {quest=55550, criteria=0, label=CHEST_MECH, requires_no_buff=296644, note="Mechanized Chest 4"},
+        -- Chest 5, 325663, Alt Mechagon only
+        [61403250] = {quest=55551, criteria=0, label=CHEST_MECH, requires_buff=296644, note="Mechanized Chest 5"},  -- Coords from wowhead
+        [58804170] = {quest=55551, criteria=0, label=CHEST_MECH, requires_buff=296644, note="Mechanized Chest 5"},  -- Coords from wowhead
+        [70654796] = {quest=55551, criteria=0, label=CHEST_MECH, requires_buff=296644, note="Mechanized Chest 5"},
+        [64365961] = {quest=55551, criteria=0, label=CHEST_MECH, requires_buff=296644, note="Mechanized Chest 5"},
+        [56705750] = {quest=55551, criteria=0, label=CHEST_MECH, requires_buff=296644, note="Mechanized Chest 5"},  -- Coords from wowhead
         -- Chest 6, 325664
-        [66502250] = {quest=55552, criteria=0, label=CHEST_MECH, note="Mechanized Chest 6"},  -- Coords from wowhead
-        [64002650] = {quest=55552, criteria=0, label=CHEST_MECH, note="Mechanized Chest 6"},  -- Coords from wowhead
-        [56782918] = {quest=55552, criteria=0, label=CHEST_MECH, note="Mechanized Chest 6"},
-        [57302290] = {quest=55552, criteria=0, label=CHEST_MECH, note="Mechanized Chest 6"},  -- Coords from wowhead
-        [55612404] = {quest=55552, criteria=0, label=CHEST_MECH, note="Mechanized Chest 6"},
-        [50802860] = {quest=55552, criteria=0, label=CHEST_MECH, note="Mechanized Chest 6"},  -- Coords from wowhead
+        [66432227] = {quest=55552, criteria=0, label=CHEST_MECH, requires_no_buff=296644, note="Mechanized Chest 6"},
+        [64092627] = {quest=55552, criteria=0, label=CHEST_MECH, requires_no_buff=296644, note="Mechanized Chest 6"},
+        [56782918] = {quest=55552, criteria=0, label=CHEST_MECH, requires_no_buff=296644, note="Mechanized Chest 6"},
+        [57302290] = {quest=55552, criteria=0, label=CHEST_MECH, requires_no_buff=296644, note="Mechanized Chest 6"},  -- Coords from wowhead
+        [55612404] = {quest=55552, criteria=0, label=CHEST_MECH, requires_no_buff=296644, note="Mechanized Chest 6"},
+        [50662858] = {quest=55552, criteria=0, label=CHEST_MECH, requires_no_buff=296644, note="Mechanized Chest 6"},
         -- Chest 7, 325665
-        [67452470] = {quest=55553, criteria=0, label=CHEST_MECH, note="Mechanized Chest 7"},
-        [80801870] = {quest=55553, criteria=0, label=CHEST_MECH, note="Mechanized Chest 7"},  -- Coords from wowhead
-        [86232042] = {quest=55553, criteria=0, label=CHEST_MECH, note="Mechanized Chest 7"},
-        [88602050] = {quest=55553, criteria=0, label=CHEST_MECH, note="Mechanized Chest 7"},  -- Coords from wowhead
-        [85602850] = {quest=55553, criteria=0, label=CHEST_MECH, note="Mechanized Chest 7"},  -- Coords from wowhead
+        [67322289] = {quest=55553, criteria=0, label=CHEST_MECH, requires_no_buff=296644, note="Mechanized Chest 7"},
+        [80801870] = {quest=55553, criteria=0, label=CHEST_MECH, requires_no_buff=296644, note="Mechanized Chest 7"},  -- Coords from wowhead
+        [86232042] = {quest=55553, criteria=0, label=CHEST_MECH, requires_no_buff=296644, note="Mechanized Chest 7"},
+        [88732015] = {quest=55553, criteria=0, label=CHEST_MECH, requires_no_buff=296644, note="Mechanized Chest 7"},
+        [85752824] = {quest=55553, criteria=0, label=CHEST_MECH, requires_no_buff=296644, note="Mechanized Chest 7"},
         -- Chest 8, 325666
-        [48367595] = {quest=55554, criteria=0, label=CHEST_MECH, note="Mechanized Chest 8"},
-        [57258202] = {quest=55554, criteria=0, label=CHEST_MECH, note="Mechanized Chest 8"},
-        [62607400] = {quest=55554, criteria=0, label=CHEST_MECH, note="Mechanized Chest 8"},  -- Coords from wowhead
-        [66707740] = {quest=55554, criteria=0, label=CHEST_MECH, note="Mechanized Chest 8"},  -- Coords from wowhead
+        [48367595] = {quest=55554, criteria=0, label=CHEST_MECH, requires_no_buff=296644, note="Mechanized Chest 8"},
+        [57258202] = {quest=55554, criteria=0, label=CHEST_MECH, requires_no_buff=296644, note="Mechanized Chest 8"},
+        [62607400] = {quest=55554, criteria=0, label=CHEST_MECH, requires_no_buff=296644, note="Mechanized Chest 8"},  -- Coords from wowhead
+        [66767759] = {quest=55554, criteria=0, label=CHEST_MECH, requires_no_buff=296644, note="Mechanized Chest 8"},
         -- Chest 9, 325667
-        [63606750] = {quest=55555, criteria=0, label=CHEST_MECH, note="Mechanized Chest 9"},  -- Coords from wowhead
-        [72126545] = {quest=55555, criteria=0, label=CHEST_MECH, note="Mechanized Chest 9"},
-        [76516601] = {quest=55555, criteria=0, label=CHEST_MECH, note="Mechanized Chest 9"},
-        [81167231] = {quest=55555, criteria=0, label=CHEST_MECH, note="Mechanized Chest 9"},
-        [85106350] = {quest=55555, criteria=0, label=CHEST_MECH, note="Mechanized Chest 9"},
+        [63626715] = {quest=55555, criteria=0, label=CHEST_MECH, requires_no_buff=296644, note="Mechanized Chest 9"},
+        [72126545] = {quest=55555, criteria=0, label=CHEST_MECH, requires_no_buff=296644, note="Mechanized Chest 9"},
+        [76516601] = {quest=55555, criteria=0, label=CHEST_MECH, requires_no_buff=296644, note="Mechanized Chest 9"},
+        [81167231] = {quest=55555, criteria=0, label=CHEST_MECH, requires_no_buff=296644, note="Mechanized Chest 9"},
+        [85106350] = {quest=55555, criteria=0, label=CHEST_MECH, requires_no_buff=296644, note="Mechanized Chest 9"},
         -- Chest 10, 325668
-        [24806550] = {quest=55556, criteria=0, label=CHEST_MECH, note="Mechanized Chest 10"},  -- Coords from wowhead
-        [20607700] = {quest=55556, criteria=0, label=CHEST_MECH, note="Mechanized Chest 10"},  -- Coords from wowhead
-        [21788303] = {quest=55556, criteria=0, label=CHEST_MECH, note="Mechanized Chest 10"},
-        [12088566] = {quest=55556, criteria=0, label=CHEST_MECH, note="Mechanized Chest 10"},
+        [24796526] = {quest=55556, criteria=0, label=CHEST_MECH, requires_no_buff=296644, note="Mechanized Chest 10"},
+        [20607700] = {quest=55556, criteria=0, label=CHEST_MECH, requires_no_buff=296644, note="Mechanized Chest 10"},  -- Coords from wowhead
+        [21788303] = {quest=55556, criteria=0, label=CHEST_MECH, requires_no_buff=296644, note="Mechanized Chest 10"},
+        [12088568] = {quest=55556, criteria=0, label=CHEST_MECH, requires_no_buff=296644, note="Mechanized Chest 10"},
     },
 }

--- a/Treasure.lua
+++ b/Treasure.lua
@@ -352,62 +352,62 @@ ns.points = {
     },
     [1462] = { -- Mechagon
         -- Chest 1, 325659
-        [43304977] = {quest=55547, criteria=0, label=CHEST_MECH, requires_no_buff=296644, note="Mechanized Chest 1"},
-        [52115326] = {quest=55547, criteria=0, label=CHEST_MECH, requires_no_buff=296644, note="Mechanized Chest 1"},
-        [53254190] = {quest=55547, criteria=0, label=CHEST_MECH, requires_no_buff=296644, note="Mechanized Chest 1"},
-        [49223021] = {quest=55547, criteria=0, label=CHEST_MECH, requires_no_buff=296644, note="Mechanized Chest 1"},
-        [56973861] = {quest=55547, criteria=0, label=CHEST_MECH, requires_no_buff=296644, note="Mechanized Chest 1"},
+        [43304977] = {quest=55547, criteria=0, label=CHEST_MECH, requires_no_buff=296644, note="Chest 1 of 9 in Normal Time"},
+        [52115326] = {quest=55547, criteria=0, label=CHEST_MECH, requires_no_buff=296644, note="Chest 1 of 9 in Normal Time"},
+        [53254190] = {quest=55547, criteria=0, label=CHEST_MECH, requires_no_buff=296644, note="Chest 1 of 9 in Normal Time"},
+        [49223021] = {quest=55547, criteria=0, label=CHEST_MECH, requires_no_buff=296644, note="Chest 1 of 9 in Normal Time"},
+        [56973861] = {quest=55547, criteria=0, label=CHEST_MECH, requires_no_buff=296644, note="Chest 1 of 9 in Normal Time"},
         -- Chest 2, 325660
-        [35683833] = {quest=55548, criteria=0, label=CHEST_MECH, requires_no_buff=296644, note="Mechanized Chest 2"},
-        [30785183] = {quest=55548, criteria=0, label=CHEST_MECH, requires_no_buff=296644, note="Mechanized Chest 2"},
-        [40155409] = {quest=55548, criteria=0, label=CHEST_MECH, requires_no_buff=296644, note="Mechanized Chest 2"},
-        [20617141] = {quest=55548, criteria=0, label=CHEST_MECH, requires_no_buff=296644, note="Mechanized Chest 2"},
+        [35683833] = {quest=55548, criteria=0, label=CHEST_MECH, requires_no_buff=296644, note="Chest 2 of 9 in Normal Time"},
+        [30785183] = {quest=55548, criteria=0, label=CHEST_MECH, requires_no_buff=296644, note="Chest 2 of 9 in Normal Time"},
+        [40155409] = {quest=55548, criteria=0, label=CHEST_MECH, requires_no_buff=296644, note="Chest 2 of 9 in Normal Time"},
+        [20617141] = {quest=55548, criteria=0, label=CHEST_MECH, requires_no_buff=296644, note="Chest 2 of 9 in Normal Time"},
         -- Chest 3, 325661
-        [80504850] = {quest=55549, criteria=0, label=CHEST_MECH, requires_no_buff=296644, note="Mechanized Chest 3"},  -- Coords from wowhead
-        [73515334] = {quest=55549, criteria=0, label=CHEST_MECH, requires_no_buff=296644, note="Mechanized Chest 3"},
-        [67075645] = {quest=55549, criteria=0, label=CHEST_MECH, requires_no_buff=296644, note="Mechanized Chest 3"},
-        [65866460] = {quest=55549, criteria=0, label=CHEST_MECH, requires_no_buff=296644, note="Mechanized Chest 3"},
-        [59946357] = {quest=55549, criteria=0, label=CHEST_MECH, requires_no_buff=296644, note="Mechanized Chest 3"},
+        [80504850] = {quest=55549, criteria=0, label=CHEST_MECH, requires_no_buff=296644, note="Chest 3 of 9 in Normal Time"},  -- Coords from wowhead
+        [73515334] = {quest=55549, criteria=0, label=CHEST_MECH, requires_no_buff=296644, note="Chest 3 of 9 in Normal Time"},
+        [67075645] = {quest=55549, criteria=0, label=CHEST_MECH, requires_no_buff=296644, note="Chest 3 of 9 in Normal Time"},
+        [65866460] = {quest=55549, criteria=0, label=CHEST_MECH, requires_no_buff=296644, note="Chest 3 of 9 in Normal Time"},
+        [59946357] = {quest=55549, criteria=0, label=CHEST_MECH, requires_no_buff=296644, note="Chest 3 of 9 in Normal Time"},
         -- Chest 4, 325662
-        [65555284] = {quest=55550, criteria=0, label=CHEST_MECH, requires_no_buff=296644, note="Mechanized Chest 4"},
-        [72594733] = {quest=55550, criteria=0, label=CHEST_MECH, requires_no_buff=296644, note="Mechanized Chest 4"},
-        [73014950] = {quest=55550, criteria=0, label=CHEST_MECH, requires_no_buff=296644, note="Mechanized Chest 4"},
-        [76215286] = {quest=55550, criteria=0, label=CHEST_MECH, requires_no_buff=296644, note="Mechanized Chest 4"},
-        [81106150] = {quest=55550, criteria=0, label=CHEST_MECH, requires_no_buff=296644, note="Mechanized Chest 4"},
+        [65555284] = {quest=55550, criteria=0, label=CHEST_MECH, requires_no_buff=296644, note="Chest 4 of 9 in Normal Time"},
+        [72594733] = {quest=55550, criteria=0, label=CHEST_MECH, requires_no_buff=296644, note="Chest 4 of 9 in Normal Time"},
+        [73014950] = {quest=55550, criteria=0, label=CHEST_MECH, requires_no_buff=296644, note="Chest 4 of 9 in Normal Time"},
+        [76215286] = {quest=55550, criteria=0, label=CHEST_MECH, requires_no_buff=296644, note="Chest 4 of 9 in Normal Time"},
+        [81106150] = {quest=55550, criteria=0, label=CHEST_MECH, requires_no_buff=296644, note="Chest 4 of 9 in Normal Time"},
         -- Chest 5, 325663, Alt Mechagon only
-        [61403250] = {quest=55551, criteria=0, label=CHEST_MECH, requires_buff=296644, note="Mechanized Chest 5"},  -- Coords from wowhead
-        [58804170] = {quest=55551, criteria=0, label=CHEST_MECH, requires_buff=296644, note="Mechanized Chest 5"},  -- Coords from wowhead
-        [70654796] = {quest=55551, criteria=0, label=CHEST_MECH, requires_buff=296644, note="Mechanized Chest 5"},
-        [64365961] = {quest=55551, criteria=0, label=CHEST_MECH, requires_buff=296644, note="Mechanized Chest 5"},
-        [56705750] = {quest=55551, criteria=0, label=CHEST_MECH, requires_buff=296644, note="Mechanized Chest 5"},  -- Coords from wowhead
+        [61403250] = {quest=55551, criteria=0, label=CHEST_MECH, requires_buff=296644, note="Chest 1 of 1 in Alternate Time"},  -- Coords from wowhead
+        [58804170] = {quest=55551, criteria=0, label=CHEST_MECH, requires_buff=296644, note="Chest 1 of 1 in Alternate Time"},  -- Coords from wowhead
+        [70654796] = {quest=55551, criteria=0, label=CHEST_MECH, requires_buff=296644, note="Chest 1 of 1 in Alternate Time"},
+        [64365961] = {quest=55551, criteria=0, label=CHEST_MECH, requires_buff=296644, note="Chest 1 of 1 in Alternate Time"},
+        [56705750] = {quest=55551, criteria=0, label=CHEST_MECH, requires_buff=296644, note="Chest 1 of 1 in Alternate Time"},  -- Coords from wowhead
         -- Chest 6, 325664
-        [66432227] = {quest=55552, criteria=0, label=CHEST_MECH, requires_no_buff=296644, note="Mechanized Chest 6"},
-        [64092627] = {quest=55552, criteria=0, label=CHEST_MECH, requires_no_buff=296644, note="Mechanized Chest 6"},
-        [56782918] = {quest=55552, criteria=0, label=CHEST_MECH, requires_no_buff=296644, note="Mechanized Chest 6"},
-        [57302290] = {quest=55552, criteria=0, label=CHEST_MECH, requires_no_buff=296644, note="Mechanized Chest 6"},  -- Coords from wowhead
-        [55612404] = {quest=55552, criteria=0, label=CHEST_MECH, requires_no_buff=296644, note="Mechanized Chest 6"},
-        [50662858] = {quest=55552, criteria=0, label=CHEST_MECH, requires_no_buff=296644, note="Mechanized Chest 6"},
+        [66432227] = {quest=55552, criteria=0, label=CHEST_MECH, requires_no_buff=296644, note="Chest 5 of 9 in Normal Time"},
+        [64092627] = {quest=55552, criteria=0, label=CHEST_MECH, requires_no_buff=296644, note="Chest 5 of 9 in Normal Time"},
+        [56782918] = {quest=55552, criteria=0, label=CHEST_MECH, requires_no_buff=296644, note="Chest 5 of 9 in Normal Time"},
+        [57302290] = {quest=55552, criteria=0, label=CHEST_MECH, requires_no_buff=296644, note="Chest 5 of 9 in Normal Time"},  -- Coords from wowhead
+        [55612404] = {quest=55552, criteria=0, label=CHEST_MECH, requires_no_buff=296644, note="Chest 5 of 9 in Normal Time"},
+        [50662858] = {quest=55552, criteria=0, label=CHEST_MECH, requires_no_buff=296644, note="Chest 5 of 9 in Normal Time"},
         -- Chest 7, 325665
-        [67322289] = {quest=55553, criteria=0, label=CHEST_MECH, requires_no_buff=296644, note="Mechanized Chest 7"},
-        [80801870] = {quest=55553, criteria=0, label=CHEST_MECH, requires_no_buff=296644, note="Mechanized Chest 7"},  -- Coords from wowhead
-        [86232042] = {quest=55553, criteria=0, label=CHEST_MECH, requires_no_buff=296644, note="Mechanized Chest 7"},
-        [88732015] = {quest=55553, criteria=0, label=CHEST_MECH, requires_no_buff=296644, note="Mechanized Chest 7"},
-        [85752824] = {quest=55553, criteria=0, label=CHEST_MECH, requires_no_buff=296644, note="Mechanized Chest 7"},
+        [67322289] = {quest=55553, criteria=0, label=CHEST_MECH, requires_no_buff=296644, note="Chest 6 of 9 in Normal Time"},
+        [80801870] = {quest=55553, criteria=0, label=CHEST_MECH, requires_no_buff=296644, note="Chest 6 of 9 in Normal Time"},  -- Coords from wowhead
+        [86232042] = {quest=55553, criteria=0, label=CHEST_MECH, requires_no_buff=296644, note="Chest 6 of 9 in Normal Time"},
+        [88732015] = {quest=55553, criteria=0, label=CHEST_MECH, requires_no_buff=296644, note="Chest 6 of 9 in Normal Time"},
+        [85752824] = {quest=55553, criteria=0, label=CHEST_MECH, requires_no_buff=296644, note="Chest 6 of 9 in Normal Time"},
         -- Chest 8, 325666
-        [48367595] = {quest=55554, criteria=0, label=CHEST_MECH, requires_no_buff=296644, note="Mechanized Chest 8"},
-        [57258202] = {quest=55554, criteria=0, label=CHEST_MECH, requires_no_buff=296644, note="Mechanized Chest 8"},
-        [62607400] = {quest=55554, criteria=0, label=CHEST_MECH, requires_no_buff=296644, note="Mechanized Chest 8"},  -- Coords from wowhead
-        [66767759] = {quest=55554, criteria=0, label=CHEST_MECH, requires_no_buff=296644, note="Mechanized Chest 8"},
+        [48367595] = {quest=55554, criteria=0, label=CHEST_MECH, requires_no_buff=296644, note="Chest 7 of 9 in Normal Time"},
+        [57258202] = {quest=55554, criteria=0, label=CHEST_MECH, requires_no_buff=296644, note="Chest 7 of 9 in Normal Time"},
+        [62607400] = {quest=55554, criteria=0, label=CHEST_MECH, requires_no_buff=296644, note="Chest 7 of 9 in Normal Time"},  -- Coords from wowhead
+        [66767759] = {quest=55554, criteria=0, label=CHEST_MECH, requires_no_buff=296644, note="Chest 7 of 9 in Normal Time"},
         -- Chest 9, 325667
-        [63626715] = {quest=55555, criteria=0, label=CHEST_MECH, requires_no_buff=296644, note="Mechanized Chest 9"},
-        [72126545] = {quest=55555, criteria=0, label=CHEST_MECH, requires_no_buff=296644, note="Mechanized Chest 9"},
-        [76516601] = {quest=55555, criteria=0, label=CHEST_MECH, requires_no_buff=296644, note="Mechanized Chest 9"},
-        [81167231] = {quest=55555, criteria=0, label=CHEST_MECH, requires_no_buff=296644, note="Mechanized Chest 9"},
-        [85106350] = {quest=55555, criteria=0, label=CHEST_MECH, requires_no_buff=296644, note="Mechanized Chest 9"},
+        [63626715] = {quest=55555, criteria=0, label=CHEST_MECH, requires_no_buff=296644, note="Chest 8 of 9 in Normal Time"},
+        [72126545] = {quest=55555, criteria=0, label=CHEST_MECH, requires_no_buff=296644, note="Chest 8 of 9 in Normal Time"},
+        [76516601] = {quest=55555, criteria=0, label=CHEST_MECH, requires_no_buff=296644, note="Chest 8 of 9 in Normal Time"},
+        [81167231] = {quest=55555, criteria=0, label=CHEST_MECH, requires_no_buff=296644, note="Chest 8 of 9 in Normal Time"},
+        [85106350] = {quest=55555, criteria=0, label=CHEST_MECH, requires_no_buff=296644, note="Chest 8 of 9 in Normal Time"},
         -- Chest 10, 325668
-        [24796526] = {quest=55556, criteria=0, label=CHEST_MECH, requires_no_buff=296644, note="Mechanized Chest 10"},
-        [20607700] = {quest=55556, criteria=0, label=CHEST_MECH, requires_no_buff=296644, note="Mechanized Chest 10"},  -- Coords from wowhead
-        [21788303] = {quest=55556, criteria=0, label=CHEST_MECH, requires_no_buff=296644, note="Mechanized Chest 10"},
-        [12088568] = {quest=55556, criteria=0, label=CHEST_MECH, requires_no_buff=296644, note="Mechanized Chest 10"},
+        [24796526] = {quest=55556, criteria=0, label=CHEST_MECH, requires_no_buff=296644, note="Chest 9 of 9 in Normal Time"},
+        [20607700] = {quest=55556, criteria=0, label=CHEST_MECH, requires_no_buff=296644, note="Chest 9 of 9 in Normal Time"},  -- Coords from wowhead
+        [21788303] = {quest=55556, criteria=0, label=CHEST_MECH, requires_no_buff=296644, note="Chest 9 of 9 in Normal Time"},
+        [12088568] = {quest=55556, criteria=0, label=CHEST_MECH, requires_no_buff=296644, note="Chest 9 of 9 in Normal Time"},
     },
 }

--- a/Treasure.lua
+++ b/Treasure.lua
@@ -373,13 +373,13 @@ ns.points = {
         [72594733] = {quest=55550, criteria=0, label=CHEST_MECH, requires_no_buff=296644, note="Chest 4 (of 9 in Normal Time)"},
         [73014950] = {quest=55550, criteria=0, label=CHEST_MECH, requires_no_buff=296644, note="Chest 4 (of 9 in Normal Time)"},
         [76215286] = {quest=55550, criteria=0, label=CHEST_MECH, requires_no_buff=296644, note="Chest 4 (of 9 in Normal Time)"},
-        [81106150] = {quest=55550, criteria=0, label=CHEST_MECH, requires_no_buff=296644, note="Chest 4 (of 9 in Normal Time)"},
+        [81196149] = {quest=55550, criteria=0, label=CHEST_MECH, requires_no_buff=296644, note="Chest 4 (of 9 in Normal Time)"},
         -- 325663, Alt Mechagon only
         [61583230] = {quest=55551, criteria=0, label=CHEST_MECH, requires_buff=296644, note="Chest 1 (of 1 in Alternate Time)"},
-        [58804170] = {quest=55551, criteria=0, label=CHEST_MECH, requires_buff=296644, note="Chest 1 (of 1 in Alternate Time)"},  -- Coords from wowhead
+        [58634160] = {quest=55551, criteria=0, label=CHEST_MECH, requires_buff=296644, note="Chest 1 (of 1 in Alternate Time)"},
         [70654796] = {quest=55551, criteria=0, label=CHEST_MECH, requires_buff=296644, note="Chest 1 (of 1 in Alternate Time)"},
         [64365961] = {quest=55551, criteria=0, label=CHEST_MECH, requires_buff=296644, note="Chest 1 (of 1 in Alternate Time)"},
-        [56705750] = {quest=55551, criteria=0, label=CHEST_MECH, requires_buff=296644, note="Chest 1 (of 1 in Alternate Time)"},  -- Coords from wowhead
+        [56665739] = {quest=55551, criteria=0, label=CHEST_MECH, requires_buff=296644, note="Chest 1 (of 1 in Alternate Time)"},
         -- 325664
         [66432227] = {quest=55552, criteria=0, label=CHEST_MECH, requires_no_buff=296644, note="Chest 5 (of 9 in Normal Time)"},
         [64092627] = {quest=55552, criteria=0, label=CHEST_MECH, requires_no_buff=296644, note="Chest 5 (of 9 in Normal Time)"},
@@ -403,7 +403,7 @@ ns.points = {
         [72126545] = {quest=55555, criteria=0, label=CHEST_MECH, requires_no_buff=296644, note="Chest 8 (of 9 in Normal Time)"},
         [76516601] = {quest=55555, criteria=0, label=CHEST_MECH, requires_no_buff=296644, note="Chest 8 (of 9 in Normal Time)"},
         [81167231] = {quest=55555, criteria=0, label=CHEST_MECH, requires_no_buff=296644, note="Chest 8 (of 9 in Normal Time)"},
-        [85106350] = {quest=55555, criteria=0, label=CHEST_MECH, requires_no_buff=296644, note="Chest 8 (of 9 in Normal Time)"},
+        [85166335] = {quest=55555, criteria=0, label=CHEST_MECH, requires_no_buff=296644, note="Chest 8 (of 9 in Normal Time)"},
         -- 325668
         [24796526] = {quest=55556, criteria=0, label=CHEST_MECH, requires_no_buff=296644, note="Chest 9 (of 9 in Normal Time)"},
         [20537696] = {quest=55556, criteria=0, label=CHEST_MECH, requires_no_buff=296644, note="Chest 9 (of 9 in Normal Time)"},

--- a/Treasure.lua
+++ b/Treasure.lua
@@ -351,63 +351,63 @@ ns.points = {
 		[80503190] = {quest=56547, minimap=true, achievement=13549, label=AR_TRUNK, note="Up the building"}, [83003380] = path{quest=56547}, -- game quest id: 56913
     },
     [1462] = { -- Mechagon
-        -- Chest 1, 325659
-        [43304977] = {quest=55547, criteria=0, label=CHEST_MECH, requires_no_buff=296644, note="Chest 1 of 9 in Normal Time"},
-        [52115326] = {quest=55547, criteria=0, label=CHEST_MECH, requires_no_buff=296644, note="Chest 1 of 9 in Normal Time"},
-        [53254190] = {quest=55547, criteria=0, label=CHEST_MECH, requires_no_buff=296644, note="Chest 1 of 9 in Normal Time"},
-        [49223021] = {quest=55547, criteria=0, label=CHEST_MECH, requires_no_buff=296644, note="Chest 1 of 9 in Normal Time"},
-        [56973861] = {quest=55547, criteria=0, label=CHEST_MECH, requires_no_buff=296644, note="Chest 1 of 9 in Normal Time"},
-        -- Chest 2, 325660
-        [35683833] = {quest=55548, criteria=0, label=CHEST_MECH, requires_no_buff=296644, note="Chest 2 of 9 in Normal Time"},
-        [30785183] = {quest=55548, criteria=0, label=CHEST_MECH, requires_no_buff=296644, note="Chest 2 of 9 in Normal Time"},
-        [40155409] = {quest=55548, criteria=0, label=CHEST_MECH, requires_no_buff=296644, note="Chest 2 of 9 in Normal Time"},
-        [20617141] = {quest=55548, criteria=0, label=CHEST_MECH, requires_no_buff=296644, note="Chest 2 of 9 in Normal Time"},
-        -- Chest 3, 325661
-        [80504850] = {quest=55549, criteria=0, label=CHEST_MECH, requires_no_buff=296644, note="Chest 3 of 9 in Normal Time"},  -- Coords from wowhead
-        [73515334] = {quest=55549, criteria=0, label=CHEST_MECH, requires_no_buff=296644, note="Chest 3 of 9 in Normal Time"},
-        [67075645] = {quest=55549, criteria=0, label=CHEST_MECH, requires_no_buff=296644, note="Chest 3 of 9 in Normal Time"},
-        [65866460] = {quest=55549, criteria=0, label=CHEST_MECH, requires_no_buff=296644, note="Chest 3 of 9 in Normal Time"},
-        [59946357] = {quest=55549, criteria=0, label=CHEST_MECH, requires_no_buff=296644, note="Chest 3 of 9 in Normal Time"},
-        -- Chest 4, 325662
-        [65555284] = {quest=55550, criteria=0, label=CHEST_MECH, requires_no_buff=296644, note="Chest 4 of 9 in Normal Time"},
-        [72594733] = {quest=55550, criteria=0, label=CHEST_MECH, requires_no_buff=296644, note="Chest 4 of 9 in Normal Time"},
-        [73014950] = {quest=55550, criteria=0, label=CHEST_MECH, requires_no_buff=296644, note="Chest 4 of 9 in Normal Time"},
-        [76215286] = {quest=55550, criteria=0, label=CHEST_MECH, requires_no_buff=296644, note="Chest 4 of 9 in Normal Time"},
-        [81106150] = {quest=55550, criteria=0, label=CHEST_MECH, requires_no_buff=296644, note="Chest 4 of 9 in Normal Time"},
-        -- Chest 5, 325663, Alt Mechagon only
-        [61403250] = {quest=55551, criteria=0, label=CHEST_MECH, requires_buff=296644, note="Chest 1 of 1 in Alternate Time"},  -- Coords from wowhead
-        [58804170] = {quest=55551, criteria=0, label=CHEST_MECH, requires_buff=296644, note="Chest 1 of 1 in Alternate Time"},  -- Coords from wowhead
-        [70654796] = {quest=55551, criteria=0, label=CHEST_MECH, requires_buff=296644, note="Chest 1 of 1 in Alternate Time"},
-        [64365961] = {quest=55551, criteria=0, label=CHEST_MECH, requires_buff=296644, note="Chest 1 of 1 in Alternate Time"},
-        [56705750] = {quest=55551, criteria=0, label=CHEST_MECH, requires_buff=296644, note="Chest 1 of 1 in Alternate Time"},  -- Coords from wowhead
-        -- Chest 6, 325664
-        [66432227] = {quest=55552, criteria=0, label=CHEST_MECH, requires_no_buff=296644, note="Chest 5 of 9 in Normal Time"},
-        [64092627] = {quest=55552, criteria=0, label=CHEST_MECH, requires_no_buff=296644, note="Chest 5 of 9 in Normal Time"},
-        [56782918] = {quest=55552, criteria=0, label=CHEST_MECH, requires_no_buff=296644, note="Chest 5 of 9 in Normal Time"},
-        [57302290] = {quest=55552, criteria=0, label=CHEST_MECH, requires_no_buff=296644, note="Chest 5 of 9 in Normal Time"},  -- Coords from wowhead
-        [55612404] = {quest=55552, criteria=0, label=CHEST_MECH, requires_no_buff=296644, note="Chest 5 of 9 in Normal Time"},
-        [50662858] = {quest=55552, criteria=0, label=CHEST_MECH, requires_no_buff=296644, note="Chest 5 of 9 in Normal Time"},
-        -- Chest 7, 325665
-        [67322289] = {quest=55553, criteria=0, label=CHEST_MECH, requires_no_buff=296644, note="Chest 6 of 9 in Normal Time"},
-        [80801870] = {quest=55553, criteria=0, label=CHEST_MECH, requires_no_buff=296644, note="Chest 6 of 9 in Normal Time"},  -- Coords from wowhead
-        [86232042] = {quest=55553, criteria=0, label=CHEST_MECH, requires_no_buff=296644, note="Chest 6 of 9 in Normal Time"},
-        [88732015] = {quest=55553, criteria=0, label=CHEST_MECH, requires_no_buff=296644, note="Chest 6 of 9 in Normal Time"},
-        [85752824] = {quest=55553, criteria=0, label=CHEST_MECH, requires_no_buff=296644, note="Chest 6 of 9 in Normal Time"},
-        -- Chest 8, 325666
-        [48367595] = {quest=55554, criteria=0, label=CHEST_MECH, requires_no_buff=296644, note="Chest 7 of 9 in Normal Time"},
-        [57258202] = {quest=55554, criteria=0, label=CHEST_MECH, requires_no_buff=296644, note="Chest 7 of 9 in Normal Time"},
-        [62607400] = {quest=55554, criteria=0, label=CHEST_MECH, requires_no_buff=296644, note="Chest 7 of 9 in Normal Time"},  -- Coords from wowhead
-        [66767759] = {quest=55554, criteria=0, label=CHEST_MECH, requires_no_buff=296644, note="Chest 7 of 9 in Normal Time"},
-        -- Chest 9, 325667
-        [63626715] = {quest=55555, criteria=0, label=CHEST_MECH, requires_no_buff=296644, note="Chest 8 of 9 in Normal Time"},
-        [72126545] = {quest=55555, criteria=0, label=CHEST_MECH, requires_no_buff=296644, note="Chest 8 of 9 in Normal Time"},
-        [76516601] = {quest=55555, criteria=0, label=CHEST_MECH, requires_no_buff=296644, note="Chest 8 of 9 in Normal Time"},
-        [81167231] = {quest=55555, criteria=0, label=CHEST_MECH, requires_no_buff=296644, note="Chest 8 of 9 in Normal Time"},
-        [85106350] = {quest=55555, criteria=0, label=CHEST_MECH, requires_no_buff=296644, note="Chest 8 of 9 in Normal Time"},
-        -- Chest 10, 325668
-        [24796526] = {quest=55556, criteria=0, label=CHEST_MECH, requires_no_buff=296644, note="Chest 9 of 9 in Normal Time"},
-        [20607700] = {quest=55556, criteria=0, label=CHEST_MECH, requires_no_buff=296644, note="Chest 9 of 9 in Normal Time"},  -- Coords from wowhead
-        [21788303] = {quest=55556, criteria=0, label=CHEST_MECH, requires_no_buff=296644, note="Chest 9 of 9 in Normal Time"},
-        [12088568] = {quest=55556, criteria=0, label=CHEST_MECH, requires_no_buff=296644, note="Chest 9 of 9 in Normal Time"},
+        -- 325659
+        [43304977] = {quest=55547, criteria=0, label=CHEST_MECH, requires_no_buff=296644, note="Chest 1 (of 9 in Normal Time)"},
+        [52115326] = {quest=55547, criteria=0, label=CHEST_MECH, requires_no_buff=296644, note="Chest 1 (of 9 in Normal Time)"},
+        [53254190] = {quest=55547, criteria=0, label=CHEST_MECH, requires_no_buff=296644, note="Chest 1 (of 9 in Normal Time)"},
+        [49223021] = {quest=55547, criteria=0, label=CHEST_MECH, requires_no_buff=296644, note="Chest 1 (of 9 in Normal Time)"},
+        [56973861] = {quest=55547, criteria=0, label=CHEST_MECH, requires_no_buff=296644, note="Chest 1 (of 9 in Normal Time)"},
+        -- 325660
+        [35683833] = {quest=55548, criteria=0, label=CHEST_MECH, requires_no_buff=296644, note="Chest 2 (of 9 in Normal Time)"},
+        [30785183] = {quest=55548, criteria=0, label=CHEST_MECH, requires_no_buff=296644, note="Chest 2 (of 9 in Normal Time)"},
+        [40155409] = {quest=55548, criteria=0, label=CHEST_MECH, requires_no_buff=296644, note="Chest 2 (of 9 in Normal Time)"},
+        [20617141] = {quest=55548, criteria=0, label=CHEST_MECH, requires_no_buff=296644, note="Chest 2 (of 9 in Normal Time)"},
+        -- 325661
+        [80374838] = {quest=55549, criteria=0, label=CHEST_MECH, requires_no_buff=296644, note="Chest 3 (of 9 in Normal Time)"},
+        [73515334] = {quest=55549, criteria=0, label=CHEST_MECH, requires_no_buff=296644, note="Chest 3 (of 9 in Normal Time)"},
+        [67075645] = {quest=55549, criteria=0, label=CHEST_MECH, requires_no_buff=296644, note="Chest 3 (of 9 in Normal Time)"},
+        [65866460] = {quest=55549, criteria=0, label=CHEST_MECH, requires_no_buff=296644, note="Chest 3 (of 9 in Normal Time)"},
+        [59946357] = {quest=55549, criteria=0, label=CHEST_MECH, requires_no_buff=296644, note="Chest 3 (of 9 in Normal Time)"},
+        -- 325662
+        [65555284] = {quest=55550, criteria=0, label=CHEST_MECH, requires_no_buff=296644, note="Chest 4 (of 9 in Normal Time)"},
+        [72594733] = {quest=55550, criteria=0, label=CHEST_MECH, requires_no_buff=296644, note="Chest 4 (of 9 in Normal Time)"},
+        [73014950] = {quest=55550, criteria=0, label=CHEST_MECH, requires_no_buff=296644, note="Chest 4 (of 9 in Normal Time)"},
+        [76215286] = {quest=55550, criteria=0, label=CHEST_MECH, requires_no_buff=296644, note="Chest 4 (of 9 in Normal Time)"},
+        [81106150] = {quest=55550, criteria=0, label=CHEST_MECH, requires_no_buff=296644, note="Chest 4 (of 9 in Normal Time)"},
+        -- 325663, Alt Mechagon only
+        [61583230] = {quest=55551, criteria=0, label=CHEST_MECH, requires_buff=296644, note="Chest 1 (of 1 in Alternate Time)"},
+        [58804170] = {quest=55551, criteria=0, label=CHEST_MECH, requires_buff=296644, note="Chest 1 (of 1 in Alternate Time)"},  -- Coords from wowhead
+        [70654796] = {quest=55551, criteria=0, label=CHEST_MECH, requires_buff=296644, note="Chest 1 (of 1 in Alternate Time)"},
+        [64365961] = {quest=55551, criteria=0, label=CHEST_MECH, requires_buff=296644, note="Chest 1 (of 1 in Alternate Time)"},
+        [56705750] = {quest=55551, criteria=0, label=CHEST_MECH, requires_buff=296644, note="Chest 1 (of 1 in Alternate Time)"},  -- Coords from wowhead
+        -- 325664
+        [66432227] = {quest=55552, criteria=0, label=CHEST_MECH, requires_no_buff=296644, note="Chest 5 (of 9 in Normal Time)"},
+        [64092627] = {quest=55552, criteria=0, label=CHEST_MECH, requires_no_buff=296644, note="Chest 5 (of 9 in Normal Time)"},
+        [56782918] = {quest=55552, criteria=0, label=CHEST_MECH, requires_no_buff=296644, note="Chest 5 (of 9 in Normal Time)"},
+        [57302290] = {quest=55552, criteria=0, label=CHEST_MECH, requires_no_buff=296644, note="Chest 5 (of 9 in Normal Time)"},  -- Coords from wowhead
+        [55612404] = {quest=55552, criteria=0, label=CHEST_MECH, requires_no_buff=296644, note="Chest 5 (of 9 in Normal Time)"},
+        [50662858] = {quest=55552, criteria=0, label=CHEST_MECH, requires_no_buff=296644, note="Chest 5 (of 9 in Normal Time)"},
+        -- 325665
+        [67322289] = {quest=55553, criteria=0, label=CHEST_MECH, requires_no_buff=296644, note="Chest 6 (of 9 in Normal Time)"},
+        [80691868] = {quest=55553, criteria=0, label=CHEST_MECH, requires_no_buff=296644, note="Chest 6 (of 9 in Normal Time)"},
+        [86232042] = {quest=55553, criteria=0, label=CHEST_MECH, requires_no_buff=296644, note="Chest 6 (of 9 in Normal Time)"},
+        [88732015] = {quest=55553, criteria=0, label=CHEST_MECH, requires_no_buff=296644, note="Chest 6 (of 9 in Normal Time)"},
+        [85752824] = {quest=55553, criteria=0, label=CHEST_MECH, requires_no_buff=296644, note="Chest 6 (of 9 in Normal Time)"},
+        -- 325666
+        [48367595] = {quest=55554, criteria=0, label=CHEST_MECH, requires_no_buff=296644, note="Chest 7 (of 9 in Normal Time)"},
+        [57258202] = {quest=55554, criteria=0, label=CHEST_MECH, requires_no_buff=296644, note="Chest 7 (of 9 in Normal Time)"},
+        [62297390] = {quest=55554, criteria=0, label=CHEST_MECH, requires_no_buff=296644, note="Chest 7 (of 9 in Normal Time)"},
+        [66767759] = {quest=55554, criteria=0, label=CHEST_MECH, requires_no_buff=296644, note="Chest 7 (of 9 in Normal Time)"},
+        -- 325667
+        [63626715] = {quest=55555, criteria=0, label=CHEST_MECH, requires_no_buff=296644, note="Chest 8 (of 9 in Normal Time)"},
+        [72126545] = {quest=55555, criteria=0, label=CHEST_MECH, requires_no_buff=296644, note="Chest 8 (of 9 in Normal Time)"},
+        [76516601] = {quest=55555, criteria=0, label=CHEST_MECH, requires_no_buff=296644, note="Chest 8 (of 9 in Normal Time)"},
+        [81167231] = {quest=55555, criteria=0, label=CHEST_MECH, requires_no_buff=296644, note="Chest 8 (of 9 in Normal Time)"},
+        [85106350] = {quest=55555, criteria=0, label=CHEST_MECH, requires_no_buff=296644, note="Chest 8 (of 9 in Normal Time)"},
+        -- 325668
+        [24796526] = {quest=55556, criteria=0, label=CHEST_MECH, requires_no_buff=296644, note="Chest 9 (of 9 in Normal Time)"},
+        [20537696] = {quest=55556, criteria=0, label=CHEST_MECH, requires_no_buff=296644, note="Chest 9 (of 9 in Normal Time)"},
+        [21788303] = {quest=55556, criteria=0, label=CHEST_MECH, requires_no_buff=296644, note="Chest 9 (of 9 in Normal Time)"},
+        [12088568] = {quest=55556, criteria=0, label=CHEST_MECH, requires_no_buff=296644, note="Chest 9 (of 9 in Normal Time)"},
     },
 }

--- a/Treasure.lua
+++ b/Treasure.lua
@@ -51,6 +51,8 @@ ns.points = {
             npc=[id], -- related npc id, used to display names in tooltip
             note=[string], -- some text which might be helpful
             hide_before=[id], -- hide if quest not completed
+            requires_buff=[id], -- hide if player does not have buff, mostly useful for buff-based zone phasing
+            requires_no_buff=[id] -- hide if player has buff, mostly useful for buff-based zone phasing
         },
     },
     --]]

--- a/config.lua
+++ b/config.lua
@@ -153,6 +153,20 @@ local allQuestsComplete = function(quests)
     end
 end
 
+local playerHasBuff = function(spellid)
+    local buffname = GetSpellInfo(spellid)
+    for i = 1, 40 do
+        local name = UnitBuff("player", i)
+        if not name then
+            -- reached the end, probably
+            return
+        end
+        if buffname == name then
+            return UnitBuff("player",i)
+        end
+    end
+end
+
 local player_faction = UnitFactionGroup("player")
 local player_name = UnitName("player")
 ns.should_show_point = function(coord, point, currentZone, isMinimap)
@@ -211,6 +225,12 @@ ns.should_show_point = function(coord, point, currentZone, isMinimap)
                 return false
             end
         end
+    end
+    if point.requires_buff and not playerHasBuff(point.requires_buff) then
+        return false
+    end
+    if point.requires_no_buff and playerHasBuff(point.requires_no_buff) then
+        return false
     end
     if point.hide_before and not ns.db.upcoming and not allQuestsComplete(point.hide_before) then
         return false

--- a/config.lua
+++ b/config.lua
@@ -110,6 +110,12 @@ ns.options = {
                     desc = "Show items which don't count for any achievement",
                     order = 40,
                 },
+                show_buffbased = {
+                    type = "toggle",
+                    name = "Show unavailable (buffs)",
+                    desc = "Show items which are unavailable due to an applied or missing buff (for example, Time Displacement on Mechagon Island)",
+                    order = 40,
+                },
                 -- repeatable = {
                 --     type = "toggle",
                 --     name = "Show repeatable",
@@ -226,10 +232,10 @@ ns.should_show_point = function(coord, point, currentZone, isMinimap)
             end
         end
     end
-    if point.requires_buff and not playerHasBuff(point.requires_buff) then
+    if not ns.db.show_buffbased and point.requires_buff and not playerHasBuff(point.requires_buff) then
         return false
     end
-    if point.requires_no_buff and playerHasBuff(point.requires_no_buff) then
+    if not ns.db.show_buffbased and point.requires_no_buff and playerHasBuff(point.requires_no_buff) then
         return false
     end
     if point.hide_before and not ns.db.upcoming and not allQuestsComplete(point.hide_before) then

--- a/config.lua
+++ b/config.lua
@@ -110,12 +110,6 @@ ns.options = {
                     desc = "Show items which don't count for any achievement",
                     order = 40,
                 },
-                show_buffbased = {
-                    type = "toggle",
-                    name = "Show unavailable (buffs)",
-                    desc = "Show items which are unavailable due to an applied or missing buff (for example, Time Displacement on Mechagon Island)",
-                    order = 40,
-                },
                 -- repeatable = {
                 --     type = "toggle",
                 --     name = "Show repeatable",
@@ -232,10 +226,10 @@ ns.should_show_point = function(coord, point, currentZone, isMinimap)
             end
         end
     end
-    if not ns.db.show_buffbased and point.requires_buff and not playerHasBuff(point.requires_buff) then
+    if point.requires_buff and not playerHasBuff(point.requires_buff) then
         return false
     end
-    if not ns.db.show_buffbased and point.requires_no_buff and playerHasBuff(point.requires_no_buff) then
+    if point.requires_no_buff and playerHasBuff(point.requires_no_buff) then
         return false
     end
     if point.hide_before and not ns.db.upcoming and not allQuestsComplete(point.hide_before) then


### PR DESCRIPTION
It turns out "Chest 5" spawns in Alternate-Time Mechagon only.  Showing that set of chest spawns while in Normal Mechagon is less than useful, and showing the Normal chests while in Alt Mechagon is extremely noisy if you haven't looted any of them.  While a little niche, I added a "required_buff" and "required_no_buff" option to the coordinate dictionaries, which allows for filtering based on the "Time Displacement" buff.

My main concern with this merge is that I added a "playerHasBuff" function to config.lua.  It (somewhat) duplicates code that exists in handler.lua, but I couldn't access the handler version without making its scope global.  As there are no global methods anywhere in the addon, I figured this was the lesser of two evils.

I considered adding a config option to allow people to see unavailable items due to buffs, but I think that's likely to cause users to enable the option due to a lack of understanding of its current scope.  That defeats the purpose, so I pulled it out; it was useful for testing, but I can always add it into a local branch for that.  If the usage extends past Mechagon island, then it may warrant a revisit.