### PR TITLE
Update config.lua to correct treasures showing on minimap only when ticked.

### DIFF
--- a/config.lua
+++ b/config.lua
@@ -170,7 +170,7 @@ end
 local player_faction = UnitFactionGroup("player")
 local player_name = UnitName("player")
 ns.should_show_point = function(coord, point, currentZone, isMinimap)
-    if isMinimap and not ns.db.show_on_minimap and not point.minimap then
+    if isMinimap and not ns.db.show_on_minimap then
         return false
     elseif not isMinimap and not ns.db.show_on_world then
         return false


### PR DESCRIPTION
Treasures shown on minimap, if _**EITHER**_ show on world or show on minimap is ticked (instead of just minimap). This corrects that and does not incur any new issue(s) that I am able to identify.